### PR TITLE
Oppgraderer Distroless til java17-debian12@sha256:cd099373

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java17-debian12@sha256:82ec33483644e853dad0f5e6956c675be47ba6de00a8f74dadee321b6b0febb5
+FROM gcr.io/distroless/java17-debian12@sha256:cd099373e0e21eb374fba4e136f660af65176a92553bfb6b69c9d6f05e25ae67
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+UseParallelGC -XX:ActiveProcessorCount=2"
 


### PR DESCRIPTION
Fra flex-cli