### PR TITLE
Oppgraderer Distroless til java17-debian12@sha256:8f80873d

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java17-debian12@sha256:cd099373e0e21eb374fba4e136f660af65176a92553bfb6b69c9d6f05e25ae67
+FROM gcr.io/distroless/java17-debian12@sha256:8f80873debfafc0b77dd22d03e6d34d0a716c52404ca4ca19f76f2de11000c55
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+UseParallelGC -XX:ActiveProcessorCount=2"
 


### PR DESCRIPTION
Fra flex-cli