### PR TITLE
Oppgraderer Distroless til java17-debian12@sha256:76ac1768

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java17-debian12@sha256:8f80873debfafc0b77dd22d03e6d34d0a716c52404ca4ca19f76f2de11000c55
+FROM gcr.io/distroless/java17-debian12@sha256:76ac1768c577881e3cc04a4da5bdfa650c1ae5129ecdc9b5367d61881eb05b79
 
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75.0 -XX:+UseParallelGC -XX:ActiveProcessorCount=2"
 


### PR DESCRIPTION
Fra flex-cli